### PR TITLE
URL Cleanup

### DIFF
--- a/src/test/java/io/spring/releasenotes/generator/ReleaseNotesGeneratorTests.java
+++ b/src/test/java/io/spring/releasenotes/generator/ReleaseNotesGeneratorTests.java
@@ -179,7 +179,7 @@ public class ReleaseNotesGeneratorTests {
 	public Issue newPullRequest(String title, String number, Type type, String url,
 			User user) {
 		return new Issue(number, title, user, type.getLabels(), url,
-				new PullRequest("http://example.com"));
+				new PullRequest("https://example.com"));
 	}
 
 	private enum Type {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://example.com with 1 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).