### PR TITLE
GitHubService Changed for Enterprise GitHub

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,6 +9,7 @@ To generate markdown release notes that comprise the list of bugs and issues in 
 ----
 releasenotes:
   github:
+    api-url: #defaulted to https://api.github.com
     organization:
     repository:
     username:

--- a/src/main/java/io/spring/releasenotes/github/service/GithubService.java
+++ b/src/main/java/io/spring/releasenotes/github/service/GithubService.java
@@ -46,11 +46,9 @@ public class GithubService {
 
 	private static final Pattern LINK_PATTERN = Pattern.compile("<(.+)>; rel=\"(.+)\"");
 
-	private static final String API_URL = "https://api.github.com/repos/{organization}/{repository}/";
+	private static final String MILESTONES_URI = "/repos/{organization}/{repository}/milestones";
 
-	private static final String MILESTONES_URI = API_URL + "milestones";
-
-	private static final String ISSUES_URI = API_URL + "issues?milestone={milestone}&state=closed";
+	private static final String ISSUES_URI = "/repos/{organization}/{repository}/issues?milestone={milestone}&state=closed";
 
 	private final RestTemplate restTemplate;
 
@@ -60,6 +58,7 @@ public class GithubService {
 		if (StringUtils.hasLength(username)) {
 			builder = builder.basicAuthentication(username, password);
 		}
+		builder = builder.rootUri(properties.getGithub().getApiUrl());
 		this.restTemplate = builder.build();
 	}
 

--- a/src/main/java/io/spring/releasenotes/properties/ApplicationProperties.java
+++ b/src/main/java/io/spring/releasenotes/properties/ApplicationProperties.java
@@ -54,6 +54,11 @@ public class ApplicationProperties {
 	public static class Github {
 
 		/**
+		 * The base url to github's api.
+		 */
+		private String apiUrl = "https://api.github.com";
+
+		/**
 		 * The username for the github user.
 		 */
 		private String username;
@@ -72,6 +77,14 @@ public class ApplicationProperties {
 		 * The name of the github repository.
 		 */
 		private String repository;
+
+		public String getApiUrl() {
+			return this.apiUrl;
+		}
+
+		public void setApiUrl(String apiUrl) {
+			this.apiUrl = apiUrl;
+		}
 
 		public String getOrganization() {
 			return this.organization;

--- a/src/test/java/io/spring/releasenotes/github/service/GithubServiceTests.java
+++ b/src/test/java/io/spring/releasenotes/github/service/GithubServiceTests.java
@@ -48,11 +48,9 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 @RestClientTest({ GithubService.class })
 public class GithubServiceTests {
 
-	private static final String API_URL = "https://api.github.com/repos/org/repo/";
+	private static final String MILESTONES_URL = "/repos/org/repo/milestones";
 
-	private static final String MILESTONES_URL = API_URL + "milestones";
-
-	private static final String ISSUES_URL = API_URL + "issues?milestone=";
+	private static final String ISSUES_URL = "/repos/org/repo/issues?milestone=";
 
 	@Autowired
 	private MockRestServiceServer server;


### PR DESCRIPTION
Created a new application property of api-url. This property default is GitHub api url (https://api.github.com). When using an enterprise GitHub platform the user can override it via this property.