### PR TITLE
Allow setting of a default prefix for headings

### DIFF
--- a/src/main/java/io/spring/githubchangeloggenerator/ApplicationProperties.java
+++ b/src/main/java/io/spring/githubchangeloggenerator/ApplicationProperties.java
@@ -50,6 +50,12 @@ public class ApplicationProperties {
 	private final MilestoneReference milestoneReference;
 
 	/**
+	 * The default prefix for headings and titles - typically this contains the header
+	 * markdown e.g., "## ".
+	 */
+	private final String defaultTitlePrefix;
+
+	/**
 	 * Section definitions in the order that they should appear.
 	 */
 	private final List<Section> sections;
@@ -70,10 +76,12 @@ public class ApplicationProperties {
 	private final List<ExternalLink> externalLinks;
 
 	public ApplicationProperties(Repository repository, @DefaultValue("title") MilestoneReference milestoneReference,
-			List<Section> sections, Issues issues, Contributors contributors, List<ExternalLink> externalLinks) {
+			@DefaultValue("## ") String defaultTitlePrefix, List<Section> sections, Issues issues,
+			Contributors contributors, List<ExternalLink> externalLinks) {
 		Assert.notNull(repository, "Repository must not be null");
 		this.repository = repository;
 		this.milestoneReference = milestoneReference;
+		this.defaultTitlePrefix = defaultTitlePrefix;
 		this.sections = (sections != null) ? sections : Collections.emptyList();
 		this.issues = (issues != null) ? issues : new Issues(null, null, null);
 		this.contributors = (contributors != null) ? contributors : new Contributors(null, null);
@@ -86,6 +94,10 @@ public class ApplicationProperties {
 
 	public MilestoneReference getMilestoneReference() {
 		return this.milestoneReference;
+	}
+
+	public String getDefaultTitlePrefix() {
+		return this.defaultTitlePrefix;
 	}
 
 	public List<Section> getSections() {

--- a/src/main/java/io/spring/githubchangeloggenerator/ChangelogGenerator.java
+++ b/src/main/java/io/spring/githubchangeloggenerator/ChangelogGenerator.java
@@ -63,6 +63,8 @@ public class ChangelogGenerator {
 
 	private final MilestoneReference milestoneReference;
 
+	private final String defaultTitlePrefix;
+
 	private final IssueSort sort;
 
 	private final Set<String> excludeLabels;
@@ -81,6 +83,7 @@ public class ChangelogGenerator {
 		this.service = service;
 		this.repository = properties.getRepository();
 		this.milestoneReference = properties.getMilestoneReference();
+		this.defaultTitlePrefix = properties.getDefaultTitlePrefix();
 		this.sort = properties.getIssues().getSort();
 		this.excludeLabels = properties.getIssues().getExcludes().getLabels();
 		this.excludeContributors = properties.getContributors().getExclude().getNames();
@@ -146,7 +149,7 @@ public class ChangelogGenerator {
 		sectionIssues.forEach((section, issues) -> {
 			sort(section.getSort(), issues);
 			content.append((content.length() != 0) ? String.format("%n") : "");
-			content.append("## ").append(section).append(String.format("%n%n"));
+			content.append(this.defaultTitlePrefix).append(section).append(String.format("%n%n"));
 			issues.stream().map(this::getFormattedIssue).forEach(content::append);
 		});
 	}
@@ -199,7 +202,7 @@ public class ChangelogGenerator {
 	}
 
 	private void addContributorsContent(StringBuilder content, Set<User> contributors) {
-		content.append(String.format("%n## "));
+		content.append(String.format("%n%s", this.defaultTitlePrefix));
 		content.append((this.contributorsTitle != null) ? this.contributorsTitle : ":heart: Contributors");
 		content.append(String.format("%n%nWe'd like to thank all the contributors who worked on this release!%n%n"));
 		contributors.stream().map(this::formatContributors).forEach(content::append);
@@ -210,7 +213,7 @@ public class ChangelogGenerator {
 	}
 
 	private void addExternalLinksContent(StringBuilder content, List<ExternalLink> externalLinks) {
-		content.append(String.format("## "));
+		content.append(this.defaultTitlePrefix);
 		content.append(String.format("External Links%n%n"));
 		externalLinks.stream().map(this::formatExternalLinks).forEach(content::append);
 	}

--- a/src/test/java/io/spring/githubchangeloggenerator/ChangelogSectionsTests.java
+++ b/src/test/java/io/spring/githubchangeloggenerator/ChangelogSectionsTests.java
@@ -46,8 +46,8 @@ class ChangelogSectionsTests {
 		Issue bug = createIssue("2", "bug");
 		Issue documentation = createIssue("3", "documentation");
 		Issue dependencyUpgrade = createIssue("4", "dependency-upgrade");
-		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, null, null, null,
-				null);
+		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, "## ", null, null,
+				null, null);
 		ChangelogSections sections = new ChangelogSections(properties);
 		Map<ChangelogSection, List<Issue>> collated = sections
 				.collate(Arrays.asList(enhancement, bug, documentation, dependencyUpgrade));
@@ -67,8 +67,8 @@ class ChangelogSectionsTests {
 		ApplicationProperties.Section bugsSection = new ApplicationProperties.Section(":beetle: Bug Fixes", null, null,
 				Collections.singleton("bug"));
 		List<ApplicationProperties.Section> customSections = Arrays.asList(breaksPassivitySection, bugsSection);
-		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, customSections,
-				null, null, null);
+		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, "## ",
+				customSections, null, null, null);
 		ChangelogSections sections = new ChangelogSections(properties);
 		Issue bug = createIssue("1", "bug");
 		Issue nonPassive = createIssue("1", "breaks-passivity");
@@ -80,8 +80,8 @@ class ChangelogSectionsTests {
 	@Test
 	void collateWhenNoIssuesInSectionExcludesSection() {
 		Issue bug = createIssue("1", "bug");
-		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, null, null, null,
-				null);
+		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, "## ", null, null,
+				null, null);
 		ChangelogSections sections = new ChangelogSections(properties);
 		Map<ChangelogSection, List<Issue>> collated = sections.collate(Collections.singletonList(bug));
 		Map<String, List<Issue>> bySection = getBySection(collated);
@@ -92,8 +92,8 @@ class ChangelogSectionsTests {
 	void collateWhenIssueDoesNotMatchAnySectionLabelThenExcludesIssue() {
 		Issue bug = createIssue("1", "bug");
 		Issue nonPassive = createIssue("2", "non-passive");
-		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, null, null, null,
-				null);
+		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, "## ", null, null,
+				null, null);
 		ChangelogSections sections = new ChangelogSections(properties);
 		Map<ChangelogSection, List<Issue>> collated = sections.collate(Arrays.asList(bug, nonPassive));
 		Map<String, List<Issue>> bySection = getBySection(collated);
@@ -111,8 +111,8 @@ class ChangelogSectionsTests {
 		ApplicationProperties.Section highlights = new ApplicationProperties.Section("Highlights", null, null,
 				Collections.singleton("highlight"));
 		List<ApplicationProperties.Section> customSections = Arrays.asList(bugs, highlights);
-		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, customSections,
-				null, null, null);
+		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, "## ",
+				customSections, null, null, null);
 		ChangelogSections sections = new ChangelogSections(properties);
 		Map<ChangelogSection, List<Issue>> collated = sections.collate(Arrays.asList(bug, highlight, bugAndHighlight));
 		Map<String, List<Issue>> bySection = getBySection(collated);
@@ -131,8 +131,8 @@ class ChangelogSectionsTests {
 		ApplicationProperties.Section highlights = new ApplicationProperties.Section("Highlights", "highlights", null,
 				Collections.singleton("highlight"));
 		List<ApplicationProperties.Section> customSections = Arrays.asList(bugs, highlights);
-		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, customSections,
-				null, null, null);
+		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, "## ",
+				customSections, null, null, null);
 		ChangelogSections sections = new ChangelogSections(properties);
 		Map<ChangelogSection, List<Issue>> collated = sections.collate(Arrays.asList(bug, highlight, bugAndHighlight));
 		Map<String, List<Issue>> bySection = getBySection(collated);

--- a/src/test/resources/io/spring/githubchangeloggenerator/output-with-custom-title-prefix
+++ b/src/test/resources/io/spring/githubchangeloggenerator/output-with-custom-title-prefix
@@ -1,0 +1,19 @@
+== Enhancements
+
+- Enhancement 1 [#1](enhancement-1-url)
+- Enhancement 2 [#2](enhancement-2-url)
+- enHAncEMent a [#3](enhancement-3-url)
+- Enhancement c [#1](enhancement-1-url)
+- Enhancement z [#2](enhancement-2-url)
+
+== :heart: Contributors
+
+We'd like to thank all the contributors who worked on this release!
+
+- [@contributor1](contributor1-github-url)
+- [@contributor2](contributor2-github-url)
+== External Links
+
+- [Release Notes Link 1](url1)
+- [Release Notes Link 2](url2)
+- [Release Notes Link 3](url3)


### PR DESCRIPTION
Fixes gh-56 / Closes #56 

There is scope for overriding this per-heading (e.g. via the yml configuration) and adding a suffix (e.g. to allow for `== header ==` style headings) but I figure let's start of with a smaller PR first :+1: 