### PR TITLE
Add support for matching all section labels

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,6 +93,18 @@ changelog:
     labels: ["fix"]
 ----
 
+By default, a section will include issues matching any of the configured labels.
+If you want a section to include only issues that match all configured labels, set `label-match` to `all`:
+
+[source,yaml]
+----
+changelog:
+  sections:
+  - title: "Mobile Breaking Changes"
+    labels: ["breaking change", "library: mobile"]
+    label-match: all
+----
+
 By default, adding sections will replace the default sections.
 To add sections after the defaults, add the following configuration:
 

--- a/src/main/java/io/spring/githubchangeloggenerator/ApplicationProperties.java
+++ b/src/main/java/io/spring/githubchangeloggenerator/ApplicationProperties.java
@@ -36,6 +36,7 @@ import io.spring.githubchangeloggenerator.github.service.Repository;
  * @author Mahendra Bishnoi
  * @author Gary Russell
  * @author Steven Sheehy
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 @ConfigurationProperties(prefix = "changelog")
 public class ApplicationProperties {
@@ -143,6 +144,11 @@ public class ApplicationProperties {
 		private final Set<String> labels;
 
 		/**
+		 * How configured labels are matched against an issue.
+		 */
+		private final LabelMatch labelMatch;
+
+		/**
 		 * Whether issues, pull requests or both should be included in this section.
 		 */
 		private final IssueType type;
@@ -150,11 +156,13 @@ public class ApplicationProperties {
 		private final Summary summary;
 
 		public Section(String title, @DefaultValue("default") String group, IssueSort sort, Set<String> labels,
-				@DefaultValue("any") IssueType type, @DefaultValue Summary summary) {
+				@DefaultValue("any") LabelMatch labelMatch, @DefaultValue("any") IssueType type,
+				@DefaultValue Summary summary) {
 			this.title = title;
 			this.group = (group != null) ? group : "default";
 			this.sort = sort;
 			this.labels = labels;
+			this.labelMatch = (labelMatch != null) ? labelMatch : LabelMatch.ANY;
 			this.type = type;
 			this.summary = summary;
 		}
@@ -173,6 +181,10 @@ public class ApplicationProperties {
 
 		public Set<String> getLabels() {
 			return this.labels;
+		}
+
+		public LabelMatch getLabelMatch() {
+			return this.labelMatch;
 		}
 
 		public IssueType getType() {
@@ -378,6 +390,23 @@ public class ApplicationProperties {
 		 * Sort by the title.
 		 */
 		TITLE
+
+	}
+
+	/**
+	 * How configured section labels are matched.
+	 */
+	public enum LabelMatch {
+
+		/**
+		 * Match when any configured label matches an issue label.
+		 */
+		ANY,
+
+		/**
+		 * Match when all configured labels match issue labels.
+		 */
+		ALL
 
 	}
 

--- a/src/main/java/io/spring/githubchangeloggenerator/ChangelogSections.java
+++ b/src/main/java/io/spring/githubchangeloggenerator/ChangelogSections.java
@@ -45,6 +45,7 @@ import io.spring.githubchangeloggenerator.github.service.Repository;
  * @author Phillip Webb
  * @author Gary Russell
  * @author Steven Sheehy
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 class ChangelogSections {
 
@@ -92,7 +93,7 @@ class ChangelogSections {
 	}
 
 	private ChangelogSection adapt(ApplicationProperties.Section section) {
-		Predicate<Issue> filter = SelectIssues.withLabelNamesContaining(section.getLabels());
+		Predicate<Issue> filter = SelectIssues.withLabelNamesContaining(section.getLabels(), section.getLabelMatch());
 		filter = filter.and(SelectIssues.withType(section.getType()));
 		return new ChangelogSection(section.getTitle(), section.getGroup(), section.getSort(), filter,
 				issueSummarizer(section.getSummary()));

--- a/src/main/java/io/spring/githubchangeloggenerator/SelectIssues.java
+++ b/src/main/java/io/spring/githubchangeloggenerator/SelectIssues.java
@@ -17,10 +17,12 @@
 package io.spring.githubchangeloggenerator;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
 import io.spring.githubchangeloggenerator.ApplicationProperties.IssueType;
+import io.spring.githubchangeloggenerator.ApplicationProperties.LabelMatch;
 import io.spring.githubchangeloggenerator.github.payload.Issue;
 import io.spring.githubchangeloggenerator.github.payload.Label;
 
@@ -29,6 +31,7 @@ import io.spring.githubchangeloggenerator.github.payload.Label;
  *
  * @author Phillip Webb
  * @author Steven Sheehy
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 final class SelectIssues {
 
@@ -40,10 +43,23 @@ final class SelectIssues {
 	}
 
 	static Predicate<Issue> withLabelNamesContaining(Collection<String> nameContent) {
-		return (issue) -> issue.getLabels()
-			.stream()
-			.map(Label::getName)
-			.anyMatch((name) -> nameContent.stream().anyMatch(name::contains));
+		return withLabelNamesContaining(nameContent, LabelMatch.ANY);
+	}
+
+	static Predicate<Issue> withLabelNamesContaining(Collection<String> nameContent, LabelMatch labelMatch) {
+		if (nameContent == null || nameContent.isEmpty()) {
+			return (issue) -> false;
+		}
+		LabelMatch match = (labelMatch != null) ? labelMatch : LabelMatch.ANY;
+		return (issue) -> {
+			List<String> labelNames = issue.getLabels().stream().map(Label::getName).toList();
+			return switch (match) {
+				case ANY ->
+					labelNames.stream().anyMatch((labelName) -> nameContent.stream().anyMatch(labelName::contains));
+				case ALL -> nameContent.stream()
+					.allMatch((content) -> labelNames.stream().anyMatch((labelName) -> labelName.contains(content)));
+			};
+		};
 	}
 
 	static Predicate<? super Issue> withType(IssueType type) {

--- a/src/test/java/io/spring/githubchangeloggenerator/ApplicationPropertiesTests.java
+++ b/src/test/java/io/spring/githubchangeloggenerator/ApplicationPropertiesTests.java
@@ -27,6 +27,7 @@ import org.springframework.core.io.ClassPathResource;
 
 import io.spring.githubchangeloggenerator.ApplicationProperties.IssueSort;
 import io.spring.githubchangeloggenerator.ApplicationProperties.IssueType;
+import io.spring.githubchangeloggenerator.ApplicationProperties.LabelMatch;
 import io.spring.githubchangeloggenerator.ApplicationProperties.Section;
 import io.spring.githubchangeloggenerator.github.service.Repository;
 
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Phillip Webb
  * @author Steven Sheehy
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 class ApplicationPropertiesTests {
 
@@ -56,11 +58,13 @@ class ApplicationPropertiesTests {
 		assertThat(sections.get(0).getLabels()).containsExactly("enhancement");
 		assertThat(sections.get(0).getGroup()).isEqualTo("default");
 		assertThat(sections.get(0).getSort()).isEqualTo(IssueSort.CREATED);
+		assertThat(sections.get(0).getLabelMatch()).isEqualTo(LabelMatch.ANY);
 		assertThat(sections.get(0).getType()).isEqualTo(IssueType.ISSUE);
 		assertThat(sections.get(1).getTitle()).isEqualTo("Bugs");
 		assertThat(sections.get(1).getLabels()).containsExactly("bug");
 		assertThat(sections.get(1).getGroup()).isEqualTo("test");
 		assertThat(sections.get(1).getSort()).isNull();
+		assertThat(sections.get(1).getLabelMatch()).isEqualTo(LabelMatch.ALL);
 		assertThat(sections.get(1).getType()).isEqualTo(IssueType.ANY);
 		assertThat(properties.getIssues().getExcludes().getLabels()).containsExactly("hide");
 		assertThat(properties.getIssues().getSort()).isEqualTo(IssueSort.TITLE);

--- a/src/test/java/io/spring/githubchangeloggenerator/ChangelogGeneratorTests.java
+++ b/src/test/java/io/spring/githubchangeloggenerator/ChangelogGeneratorTests.java
@@ -43,6 +43,7 @@ import io.spring.githubchangeloggenerator.ApplicationProperties.IssueSort;
 import io.spring.githubchangeloggenerator.ApplicationProperties.IssueType;
 import io.spring.githubchangeloggenerator.ApplicationProperties.Issues;
 import io.spring.githubchangeloggenerator.ApplicationProperties.IssuesExclude;
+import io.spring.githubchangeloggenerator.ApplicationProperties.LabelMatch;
 import io.spring.githubchangeloggenerator.ApplicationProperties.PortedIssue;
 import io.spring.githubchangeloggenerator.ApplicationProperties.Section;
 import io.spring.githubchangeloggenerator.ApplicationProperties.Summary;
@@ -68,6 +69,7 @@ import static org.mockito.Mockito.mock;
  * @author Mahendra Bishnoi
  * @author Gary Russell
  * @author Steven Sheehy
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 class ChangelogGeneratorTests {
 
@@ -338,7 +340,7 @@ class ChangelogGeneratorTests {
 	void generateWhenSectionSortedByTitle() throws Exception {
 		List<Section> sections = new ArrayList<>();
 		Set<String> labels = Collections.singleton("type: enhancement");
-		sections.add(new Section("Enhancements", null, IssueSort.TITLE, labels, IssueType.ANY,
+		sections.add(new Section("Enhancements", null, IssueSort.TITLE, labels, LabelMatch.ANY, IssueType.ANY,
 				new Summary(SummaryMode.TITLE, Collections.emptyMap())));
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.ID, sections,
 				new Issues(null, null, null, true), null, null, false);
@@ -355,7 +357,7 @@ class ChangelogGeneratorTests {
 	void generateWhenSectionUsesMemberCommentSummaries() throws Exception {
 		List<Section> sections = new ArrayList<>();
 		Set<String> labels = Collections.singleton("status: noteworthy");
-		sections.add(new Section("Noteworthy Changes", null, IssueSort.CREATED, labels, IssueType.ANY,
+		sections.add(new Section("Noteworthy Changes", null, IssueSort.CREATED, labels, LabelMatch.ANY, IssueType.ANY,
 				new Summary(SummaryMode.MEMBER_COMMENT, Map.of("prefix", "Noteworthy change: "))));
 		PortedIssue forwardPort = new PortedIssue("status: forward-port", "Forward port of issue #(\\d+)");
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.ID, sections,
@@ -389,7 +391,7 @@ class ChangelogGeneratorTests {
 	void generateWhenSectionUsesBodyRegexSummaries() throws Exception {
 		List<Section> sections = new ArrayList<>();
 		Set<String> labels = Collections.singleton("type: dependency-upgrade");
-		sections.add(new Section("Dependency Upgrades", null, IssueSort.TITLE, labels, IssueType.ANY,
+		sections.add(new Section("Dependency Upgrades", null, IssueSort.TITLE, labels, LabelMatch.ANY, IssueType.ANY,
 				new Summary(SummaryMode.BODY_REGEX, Map.of("expression", "(Upgrade to \\[.*\\]\\(.*\\)).*"))));
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.ID, sections,
 				new Issues(null, null, null, true), null, null, false);
@@ -408,7 +410,7 @@ class ChangelogGeneratorTests {
 	void generateWhenAllIssuesSortedByTitle() throws Exception {
 		List<Section> sections = new ArrayList<>();
 		Set<String> labels = Collections.singleton("type: enhancement");
-		sections.add(new Section("Enhancements", null, null, labels, IssueType.ANY,
+		sections.add(new Section("Enhancements", null, null, labels, LabelMatch.ANY, IssueType.ANY,
 				new Summary(SummaryMode.TITLE, Collections.emptyMap())));
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.ID, sections,
 				new Issues(IssueSort.TITLE, null, null, true), null, null, false);
@@ -474,7 +476,7 @@ class ChangelogGeneratorTests {
 	void generateWhenIssuesOnly() throws Exception {
 		List<Section> sections = new ArrayList<>();
 		Set<String> labels = Collections.singleton("type: enhancement");
-		sections.add(new Section("Enhancements", null, IssueSort.TITLE, labels, IssueType.ISSUE,
+		sections.add(new Section("Enhancements", null, IssueSort.TITLE, labels, LabelMatch.ANY, IssueType.ISSUE,
 				new Summary(SummaryMode.TITLE, Collections.emptyMap())));
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.ID, sections,
 				new Issues(null, null, null, true), null, null, false);
@@ -493,7 +495,7 @@ class ChangelogGeneratorTests {
 	void generateWhenPullRequestsOnly() throws Exception {
 		List<Section> sections = new ArrayList<>();
 		Set<String> labels = Collections.singleton("type: enhancement");
-		sections.add(new Section("Enhancements", null, IssueSort.TITLE, labels, IssueType.PULL_REQUEST,
+		sections.add(new Section("Enhancements", null, IssueSort.TITLE, labels, LabelMatch.ANY, IssueType.PULL_REQUEST,
 				new Summary(SummaryMode.TITLE, Collections.emptyMap())));
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.ID, sections,
 				new Issues(null, null, null, true), null, null, false);

--- a/src/test/java/io/spring/githubchangeloggenerator/ChangelogSectionsTests.java
+++ b/src/test/java/io/spring/githubchangeloggenerator/ChangelogSectionsTests.java
@@ -21,11 +21,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
 import io.spring.githubchangeloggenerator.ApplicationProperties.IssueType;
+import io.spring.githubchangeloggenerator.ApplicationProperties.LabelMatch;
 import io.spring.githubchangeloggenerator.ApplicationProperties.Summary;
 import io.spring.githubchangeloggenerator.ApplicationProperties.SummaryMode;
 import io.spring.githubchangeloggenerator.github.payload.Comment.AuthorAssociation;
@@ -44,6 +46,7 @@ import static org.mockito.Mockito.mock;
  * @author Phillip Webb
  * @author Gary Russell
  * @author Steven Sheehy
+ * @author Venkata Naga Sai Srikanth Gollapudi
  */
 class ChangelogSectionsTests {
 
@@ -76,10 +79,10 @@ class ChangelogSectionsTests {
 	@Test
 	void collateWhenHasCustomSectionsUsesDefinedSections() {
 		ApplicationProperties.Section breaksPassivitySection = new ApplicationProperties.Section(":rewind: Non-passive",
-				null, null, Collections.singleton("breaks-passivity"), IssueType.ANY,
+				null, null, Collections.singleton("breaks-passivity"), LabelMatch.ANY, IssueType.ANY,
 				new Summary(SummaryMode.TITLE, Collections.emptyMap()));
 		ApplicationProperties.Section bugsSection = new ApplicationProperties.Section(":lady_beetle: Bug Fixes", null,
-				null, Collections.singleton("bug"), IssueType.ANY,
+				null, Collections.singleton("bug"), LabelMatch.ANY, IssueType.ANY,
 				new Summary(SummaryMode.TITLE, Collections.emptyMap()));
 		List<ApplicationProperties.Section> customSections = Arrays.asList(breaksPassivitySection, bugsSection);
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, customSections,
@@ -95,7 +98,7 @@ class ChangelogSectionsTests {
 	@Test
 	void collateWhenHasCustomSectionsUsesDefinedSectionsAndDefault() {
 		ApplicationProperties.Section breaksPassivitySection = new ApplicationProperties.Section(":rewind: Non-passive",
-				null, null, Collections.singleton("breaks-passivity"), IssueType.ANY,
+				null, null, Collections.singleton("breaks-passivity"), LabelMatch.ANY, IssueType.ANY,
 				new Summary(SummaryMode.TITLE, Collections.emptyMap()));
 		List<ApplicationProperties.Section> customSections = List.of(breaksPassivitySection);
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, customSections,
@@ -106,6 +109,33 @@ class ChangelogSectionsTests {
 		Map<ChangelogSection, List<Issue>> collated = sections.collate(Arrays.asList(bug, nonPassive));
 		Map<String, List<Issue>> bySection = getBySection(collated);
 		assertThat(bySection).containsOnlyKeys(":lady_beetle: Bug Fixes", ":rewind: Non-passive");
+	}
+
+	@Test
+	void collateWhenSectionLabelMatchIsAllOnlyIncludesIssuesWithAllLabels() {
+		ApplicationProperties.Section mobileBreakingChanges = new ApplicationProperties.Section(
+				"Mobile Breaking Changes", "mobile-breaking-changes", null,
+				Set.of("breaking change", "library: mobile"), LabelMatch.ALL, IssueType.ANY,
+				new Summary(SummaryMode.TITLE, Collections.emptyMap()));
+		ApplicationProperties.Section desktopBreakingChanges = new ApplicationProperties.Section(
+				"Desktop Breaking Changes", "desktop-breaking-changes", null,
+				Set.of("breaking change", "library: desktop"), LabelMatch.ALL, IssueType.ANY,
+				new Summary(SummaryMode.TITLE, Collections.emptyMap()));
+		List<ApplicationProperties.Section> customSections = Arrays.asList(mobileBreakingChanges,
+				desktopBreakingChanges);
+		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, customSections,
+				null, null, null, false);
+		ChangelogSections sections = new ChangelogSections(properties, this.github, this.issueChain);
+		Issue breakingChange = createIssue("1", "breaking change");
+		Issue mobile = createIssue("2", "library: mobile");
+		Issue mobileBreakingChange = createIssue("3", "breaking change", "library: mobile");
+		Issue desktopBreakingChange = createIssue("4", "breaking change", "library: desktop");
+		Map<ChangelogSection, List<Issue>> collated = sections
+			.collate(Arrays.asList(breakingChange, mobile, mobileBreakingChange, desktopBreakingChange));
+		Map<String, List<Issue>> bySection = getBySection(collated);
+		assertThat(bySection).containsOnlyKeys("Mobile Breaking Changes", "Desktop Breaking Changes");
+		assertThat(bySection.get("Mobile Breaking Changes")).containsExactly(mobileBreakingChange);
+		assertThat(bySection.get("Desktop Breaking Changes")).containsExactly(desktopBreakingChange);
 	}
 
 	@Test
@@ -138,9 +168,10 @@ class ChangelogSectionsTests {
 		Issue highlight = createIssue("2", "highlight");
 		Issue bugAndHighlight = createIssue("3", "bug", "highlight");
 		ApplicationProperties.Section bugs = new ApplicationProperties.Section("Bugs", null, null,
-				Collections.singleton("bug"), IssueType.ANY, new Summary(SummaryMode.TITLE, Collections.emptyMap()));
+				Collections.singleton("bug"), LabelMatch.ANY, IssueType.ANY,
+				new Summary(SummaryMode.TITLE, Collections.emptyMap()));
 		ApplicationProperties.Section highlights = new ApplicationProperties.Section("Highlights", null, null,
-				Collections.singleton("highlight"), IssueType.ANY,
+				Collections.singleton("highlight"), LabelMatch.ANY, IssueType.ANY,
 				new Summary(SummaryMode.TITLE, Collections.emptyMap()));
 		List<ApplicationProperties.Section> customSections = Arrays.asList(bugs, highlights);
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, customSections,
@@ -159,9 +190,10 @@ class ChangelogSectionsTests {
 		Issue highlight = createIssue("2", "highlight");
 		Issue bugAndHighlight = createIssue("3", "bug", "highlight");
 		ApplicationProperties.Section bugs = new ApplicationProperties.Section("Bugs", null, null,
-				Collections.singleton("bug"), IssueType.ANY, new Summary(SummaryMode.TITLE, Collections.emptyMap()));
+				Collections.singleton("bug"), LabelMatch.ANY, IssueType.ANY,
+				new Summary(SummaryMode.TITLE, Collections.emptyMap()));
 		ApplicationProperties.Section highlights = new ApplicationProperties.Section("Highlights", "highlights", null,
-				Collections.singleton("highlight"), IssueType.ANY,
+				Collections.singleton("highlight"), LabelMatch.ANY, IssueType.ANY,
 				new Summary(SummaryMode.TITLE, Collections.emptyMap()));
 		List<ApplicationProperties.Section> customSections = Arrays.asList(bugs, highlights);
 		ApplicationProperties properties = new ApplicationProperties(REPO, MilestoneReference.TITLE, customSections,

--- a/src/test/resources/io/spring/githubchangeloggenerator/test-application.yml
+++ b/src/test/resources/io/spring/githubchangeloggenerator/test-application.yml
@@ -7,6 +7,7 @@ changelog:
     type: issue
   - title: "Bugs"
     labels: ["bug"]
+    label-match: all
     group: "test"
   issues:
     sort: title


### PR DESCRIPTION
This adds support for configuring how section labels are matched when generating changelog sections.

Previously, a section matched an issue when any configured label matched one of the issue’s labels. This made it difficult to define sections that require a combination of labels, such as `breaking change` and `library: mobile`.

This change adds a new `label-match` section property with two options:

- `any`: existing behavior and the default
- `all`: requires all configured labels to match

Closes #79 

Example:

```yaml
changelog:
  sections:
  - title: "Mobile Breaking Changes"
    labels: ["breaking change", "library: mobile"]
    label-match: all